### PR TITLE
Fix error on serialization

### DIFF
--- a/lib/document_builder/model.rb
+++ b/lib/document_builder/model.rb
@@ -1,9 +1,12 @@
 module DocumentBuilder
   module Model
     module ClassMethods
-      def add_attribute(name, attribute)
+      def attributes
         @attributes ||= {}
-        @attributes[name.to_sym] = attribute
+      end
+
+      def add_attribute(name, attribute)
+       attributes[name.to_sym] = attribute
       end
 
       def property(name, selector: nil, type: nil)
@@ -51,7 +54,7 @@ module DocumentBuilder
     end
 
     def attributes
-      self.class.instance_variable_get(:@attributes)
+      self.class.attributes
     end
 
     def get_attribute(name)

--- a/lib/document_builder/model.rb
+++ b/lib/document_builder/model.rb
@@ -22,12 +22,6 @@ module DocumentBuilder
         @root = selector
       end
 
-      def inherited(subclass)
-        subclass.instance_variable_set(:@attributes, @attributes)
-        subclass.instance_variable_set(:@root, @root)
-        super
-      end
-
       def call(document)
         self.new(document)
       end

--- a/spec/document_builder/model_spec.rb
+++ b/spec/document_builder/model_spec.rb
@@ -2,19 +2,9 @@ require 'spec_helper'
 require 'nokogiri'
 
 RSpec.describe DocumentBuilder::Model do
-  DOCUMENT = <<-XML
-    <root>
-      <collection>
-        <inner-list-item>Inner Item 1</inner-list-item>
-        <inner-list-item>Inner Item 2</inner-list-item>
-      </collection>
-      <outer-list-item>Outer Item 1</outer-list-item>
-      <outer-list-item>Outer Item 2</outer-list-item>
-      <property>Some Property</property>
-    </root>
-  XML
-
-  let(:document) { Nokogiri::XML(DOCUMENT) }
+  class EmptyDocument
+    include DocumentBuilder::Model
+  end
 
   class ListItem
     include DocumentBuilder::Model
@@ -29,25 +19,57 @@ RSpec.describe DocumentBuilder::Model do
     property :property, selector: "//property", type: TextProperty
   end
 
-  subject { SomeDocument.new(document) }
+  context 'for an xml document' do
+    let(:xml) {
+      <<-XML
+        <root>
+          <collection>
+            <inner-list-item>Inner Item 1</inner-list-item>
+            <inner-list-item>Inner Item 2</inner-list-item>
+          </collection>
+          <outer-list-item>Outer Item 1</outer-list-item>
+          <outer-list-item>Outer Item 2</outer-list-item>
+          <property>Some Property</property>
+        </root>
+      XML
+    }
 
-  it 'returns the root' do
-    expect(subject.root).to eq "//root"
+    let(:document) { Nokogiri::XML(xml) }
+
+    subject { SomeDocument.new(document) }
+
+    it 'returns the root' do
+      expect(subject.root).to eq "//root"
+    end
+
+    it 'returns an innner collection' do
+      expect(subject.collection).to be_a DocumentBuilder::Collection
+      expect(subject.collection.first).to be_a ListItem
+      expect(subject.collection.first.name).to eq "Inner Item 1"
+    end
+
+    it 'returns an outer collection' do
+      expect(subject.outer_collection).to be_a DocumentBuilder::Collection
+      expect(subject.outer_collection.first).to be_a ListItem
+      expect(subject.outer_collection.first.name).to eq "Outer Item 1"
+    end
+
+    it 'returns a property' do
+      expect(subject.property).to eq "Some Property"
+    end
   end
 
-  it 'returns an innner collection' do
-    expect(subject.collection).to be_a DocumentBuilder::Collection
-    expect(subject.collection.first).to be_a ListItem
-    expect(subject.collection.first.name).to eq "Inner Item 1"
-  end
 
-  it 'returns an outer collection' do
-    expect(subject.outer_collection).to be_a DocumentBuilder::Collection
-    expect(subject.outer_collection.first).to be_a ListItem
-    expect(subject.outer_collection.first.name).to eq "Outer Item 1"
-  end
+  context 'for an empty document' do
+    let(:document) { Nokogiri::XML("") }
+    subject { EmptyDocument.new(document) }
 
-  it 'returns a property' do
-    expect(subject.property).to eq "Some Property"
+    it 'returns an empty document' do
+      expect(subject).to be_a EmptyDocument
+    end
+
+    it 'is serialized' do
+      expect(subject.to_s).to be_a String
+    end
   end
 end


### PR DESCRIPTION
This supports the case where there are no defined attributes

e.g.

``` ruby
class SomeKlass
  include DocumentBuilder::Model
end
```
